### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,10 @@ on:
     - cron:  '0 8 1 * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/


### PR DESCRIPTION
Potential fix for [https://github.com/djoamersfoort/corvee/security/code-scanning/7](https://github.com/djoamersfoort/corvee/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is needed for the `actions/checkout` step.
- `packages: write` is required for the `docker/login-action` and `docker/build-push-action` steps to push Docker images to GitHub Packages.
- `contents: read` is sufficient for the `curl` command in the `Redeploy` step.
- `packages: write` is required for the `actions/delete-package-versions` step to delete old Docker images.

The `permissions` block will be added at the workflow level to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
