### PR TITLE
feat: Make smoelen spin around

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# DJO Corvee
+Repository for the DJO Corvee.
+
+### How to test on a local machine
+1. Clone the repository.
+2. Create a venv:
+    ```bash
+    python3 -m venv venv
+    ```
+3. Activate the venv:
+    ```bash
+    source venv/bin/activate
+    ```
+    (This is a Linux command, the command may differ on other operating systems.)
+4. Install the required dependencies:
+    ```bash
+    pip install -r requirements.txt
+    ```
+5. Build/update the database:
+    ```bash
+    python3 manage.py migrate
+    ```
+6. Create a superuser:
+    ```bash
+    python3 manage.py createsuperuser
+    ```
+7. Run the server:
+    ```bash
+    python3 manage.py runserver
+    ```
+8. Navigate to `http://localhost:8000/admin` and log in with the superuser you created.
+9. Go to the `Personen` table and add some people.
+10. Navigate to `http://localhost:8000/main` to get your very own corvee dashboard!

--- a/corvee/static/script.js
+++ b/corvee/static/script.js
@@ -1,0 +1,30 @@
+addEventListener("DOMContentLoaded", () => {
+    let zIndex = 1;
+    let disappearAnimationBusy = false;
+
+    document.querySelectorAll(".card-img-top").forEach((img, i) => {
+        // for click spin
+        img.addEventListener("mousedown", () => {
+            if (img.classList.contains("click-spin")) return;
+
+            img.style.zIndex = (zIndex++).toString();
+            img.classList.add("click-spin");
+            setTimeout(() => img.classList.remove("click-spin"), 3000);
+        });
+    });
+
+    // for disappear spin
+    document.querySelectorAll(".card").forEach(card => {
+        card.querySelectorAll(".card-body a").forEach(a => {
+            a.addEventListener("click", e => {
+                e.preventDefault();
+
+                if (disappearAnimationBusy) return;
+                disappearAnimationBusy = true;
+    
+                card.classList.add("disappear-spin");
+                setTimeout(() => location.href = a.href, 2000);
+            });
+        });
+    });
+});

--- a/corvee/static/script.js
+++ b/corvee/static/script.js
@@ -3,6 +3,15 @@ addEventListener("DOMContentLoaded", () => {
     let disappearAnimationBusy = false;
 
     document.querySelectorAll(".card-img-top").forEach((img, i) => {
+        /* // for introduction spin
+        const duration = (i + 5) * 400;
+        img.style.animationDuration = `${duration}ms`;
+        setTimeout(() => {
+            img.style.animationDuration = "";
+            img.classList.remove("introduction-spin");
+        }, duration);
+        */
+
         // for click spin
         img.addEventListener("mousedown", () => {
             if (img.classList.contains("click-spin")) return;

--- a/corvee/static/style.css
+++ b/corvee/static/style.css
@@ -1,3 +1,7 @@
+body {
+  overflow-x: hidden;
+}
+
 .material-switch {
   margin: 0em 1em;
 }
@@ -58,4 +62,38 @@
   display: flex;
   justify-content: center;
   margin-bottom: 1em;
+}
+
+/* if we ever want to introduce this */
+@keyframes introduction-spin {
+  from { transform: rotate(-6000deg); }
+  to   { transform: rotate(0deg);     }
+}
+.introduction-spin {
+  animation-name: introduction-spin;
+  animation-timing-function: linear;
+  animation-iteration-count: 1;
+}
+
+@keyframes click-spin {
+  from { transform: rotate(0deg);    }
+  to   { transform: rotate(3600deg); }
+}
+.click-spin {
+  animation-name: click-spin;
+  animation-duration: 3s;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: 1;
+}
+
+@keyframes disappear-spin {
+  from { transform: rotate(0deg);             }
+  to   { transform: rotate(3600deg) scale(0); }
+}
+.disappear-spin {
+  animation-name: disappear-spin;
+  animation-duration: 2s;
+  animation-timing-function: ease-in;
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
 }

--- a/corvee/templates/index.html
+++ b/corvee/templates/index.html
@@ -12,7 +12,7 @@
     {% for person in object_list %}
       <div class="col" style="min-width: 18rem; width: 18rem;">
         <div class="card" style="min-width: 18rem; width: 18rem;">
-          <img class="card-img-top" src="{{ person.picture }}" alt="Foto van ...">
+          <img class="card-img-top" src="{{ person.picture }}" alt="Foto van {{ person.first_name }} {{ person.last_name }}">
           <div class="card-body">
             <h5 class="card-title">{{ person.first_name }} {{ person.last_name }}</h5>
             <a href="{% url 'acknowledge' person.id %}" class="card-link">Aftekenen</a>


### PR DESCRIPTION
- When clicking on a smoel, that smoel will spin around for 3 seconds (dashboard and members page);
- When clicking on a hyperlink below a smoel, that entire <div> will spin and shrink simultaneously, following the link once it is gone (dashboard page only).

The spinning on page load has been disabled, but it is commented somewhere, so it can easily be re-enabled.

Last but not least, we got a README now!